### PR TITLE
fix stream timeout

### DIFF
--- a/nginx.sh
+++ b/nginx.sh
@@ -277,8 +277,8 @@ stream() { local server=$1 dest=$2 proto=${3:-""} \
     echo -e "server { listen $server${proto:+ $proto};\n}" >>$file
 
     sed -i '/^[^#]*server { listen '"$server${proto:+ $proto}"';/a\
-    proxy_connect_timeout 1s;\
-    proxy_timeout 3s;\
+    proxy_connect_timeout 10s;\
+    proxy_timeout 1800s;\
     proxy_pass '"$dest"';' $file
 }
 


### PR DESCRIPTION
Hi,

I've found a bug in the TCP stream config, the `timeout`s values are way to short. WebSocket connection are constantly closing themselves because of the timeout in `default.stream`.

`proxy_connect_timeout`
> Defines a timeout for establishing a connection with a proxied server.

`proxy_timeout`
> Sets the timeout between two successive read or write operations on client or proxied server connections. If no data is transmitted within this time, the connection is closed.

I updated these values to a more reasonable range.


**PS: i got an armhf dockerfile for your dperson/nginx repo if you are interested, i've used it for almost a year and it works perfectly. Let me know if you are interested.**
