### PR TITLE
Add Dockerfiles form arm (32 and 64 bit) and hooks for building and t…

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,41 @@
+FROM arm32v6/nginx:alpine
+COPY qemu-aarch64-static /usr/bin/
+MAINTAINER David Personette <dperson@gmail.com>
+
+# Setup nginx
+RUN apk --no-cache --no-progress upgrade && \
+    apk --no-cache --no-progress add apache2-utils bash curl openssl shadow \
+                tini tzdata && \
+    #usermod -m -d /var/cache/nginx -s /sbin/nologin nginx && \
+    sed -i 's/#gzip/gzip/' /etc/nginx/nginx.conf && \
+    sed -i "/http_x_forwarded_for\"';/s/';/ '/" /etc/nginx/nginx.conf && \
+    sed -i "/http_x_forwarded_for/a \\\
+                      '\$request_time \$upstream_response_time';" \
+                /etc/nginx/nginx.conf && \
+    echo -e "\n\nstream {\n    include /etc/nginx/conf.d/*.stream;\n}" \
+                >>/etc/nginx/nginx.conf && \
+    [ -d /srv/www ] || mkdir -p /srv/www && \
+    { mv /usr/share/nginx/html/index.html /srv/www/ || :; } && \
+    apk add --no-cache --no-progress --virtual .gettext gettext && \
+    mv /usr/bin/envsubst /usr/local/bin/ && \
+    runDeps="$(scanelf --needed --nobanner /usr/local/bin/envsubst | \
+                awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' | \
+                sort -u | xargs -r apk info --installed | sort -u)" && \
+    apk del --no-cache --no-progress .gettext && \
+    apk add --no-cache --no-progress $runDeps && \
+    rm -rf /tmp/* && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+# Forward request and error logs to docker log collector
+
+COPY default.conf /etc/nginx/conf.d/
+COPY nginx.sh /usr/bin/
+
+VOLUME ["/srv/www", "/etc/nginx"]
+
+EXPOSE 80 443
+
+HEALTHCHECK --interval=60s --timeout=15s --start-period=120s \
+             CMD curl -Lk 'https://localhost/index.html'
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/nginx.sh"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM arm64v6/nginx:alpine
+FROM arm64v8/nginx:alpine
 COPY qemu-aarch64-static /usr/bin/
 MAINTAINER David Personette <dperson@gmail.com>
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM arm32v6/nginx:alpine
+FROM arm64v6/nginx:alpine
 COPY qemu-aarch64-static /usr/bin/
 MAINTAINER David Personette <dperson@gmail.com>
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,41 @@
+FROM arm32v6/nginx:alpine
+COPY qemu-arm-static /usr/bin/
+MAINTAINER David Personette <dperson@gmail.com>
+
+# Setup nginx
+RUN apk --no-cache --no-progress upgrade && \
+    apk --no-cache --no-progress add apache2-utils bash curl openssl shadow \
+                tini tzdata && \
+    #usermod -m -d /var/cache/nginx -s /sbin/nologin nginx && \
+    sed -i 's/#gzip/gzip/' /etc/nginx/nginx.conf && \
+    sed -i "/http_x_forwarded_for\"';/s/';/ '/" /etc/nginx/nginx.conf && \
+    sed -i "/http_x_forwarded_for/a \\\
+                      '\$request_time \$upstream_response_time';" \
+                /etc/nginx/nginx.conf && \
+    echo -e "\n\nstream {\n    include /etc/nginx/conf.d/*.stream;\n}" \
+                >>/etc/nginx/nginx.conf && \
+    [ -d /srv/www ] || mkdir -p /srv/www && \
+    { mv /usr/share/nginx/html/index.html /srv/www/ || :; } && \
+    apk add --no-cache --no-progress --virtual .gettext gettext && \
+    mv /usr/bin/envsubst /usr/local/bin/ && \
+    runDeps="$(scanelf --needed --nobanner /usr/local/bin/envsubst | \
+                awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' | \
+                sort -u | xargs -r apk info --installed | sort -u)" && \
+    apk del --no-cache --no-progress .gettext && \
+    apk add --no-cache --no-progress $runDeps && \
+    rm -rf /tmp/* && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+# Forward request and error logs to docker log collector
+
+COPY default.conf /etc/nginx/conf.d/
+COPY nginx.sh /usr/bin/
+
+VOLUME ["/srv/www", "/etc/nginx"]
+
+EXPOSE 80 443
+
+HEALTHCHECK --interval=60s --timeout=15s --start-period=120s \
+             CMD curl -Lk 'https://localhost/index.html'
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/nginx.sh"]

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+API="https://api.github.com/repos/estesp/manifest-tool/tags"
+URL="https://github.com/estesp/manifest-tool/releases/download"
+TAG=$(curl -Ls $API | awk -F'"' '/name.*v[0-9]/ {print $4; exit}')
+curl -LSso manifest-tool "${URL}/${TAG}/manifest-tool-linux-amd64"
+chmod +x manifest-tool
+
+[[ "${DOCKER_TAG}" == "amd64" ]] && \
+    { echo 'qemu-user-static: Download not required for this arch'; exit 0; }
+
+API="https://api.github.com/repos/multiarch/qemu-user-static/tags"
+URL="https://github.com/multiarch/qemu-user-static/releases/download"
+TAG=$(curl -Ls $API | awk -F'"' '/name.*v[0-9]/ {print $4; exit}')
+ARCH=$([[ "${DOCKER_TAG}" == "armhf" ]] && \
+            echo "${DOCKER_TAG::-2}" || echo "${DOCKER_TAG}")
+
+curl -LSs "${URL}/${TAG}/x86_64_qemu-${ARCH}-static.tar.gz" | tar xzv

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+
+./manifest-tool push from-spec multi-arch-manifest.yaml

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+[[ "${DOCKER_TAG}" == "amd64" ]] && \
+    { echo 'qemu-user-static: Registration not required for this arch';exit 0; }
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/multi-arch-manifest.yaml
+++ b/multi-arch-manifest.yaml
@@ -1,0 +1,16 @@
+image: dperson/torproxy:latest
+manifests:
+  - image: dperson/nginx:amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: dperson/nginx:aarch64
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  - image: dperson/nginx:armhf
+    platform:
+      architecture: arm
+      os: linux
+      variant: v6

--- a/multi-arch-manifest.yaml
+++ b/multi-arch-manifest.yaml
@@ -1,4 +1,4 @@
-image: dperson/torproxy:latest
+image: dperson/nginx:latest
 manifests:
   - image: dperson/nginx:amd64
     platform:


### PR DESCRIPTION
…he manifest

nginx does not provide binaries for download other than amd64, but they have their own alpine docker image which I used instead.

armhf works for me, I included the hook scripts from torproxy and changed the manifest file for nginx. And this time I didn't change the maintainer :)