### PR TITLE
Hostname not correctly added to ssl certificate 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN version=$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release) && \
     apk add --no-cache --no-progress nginx && \
     sed -i 's/#gzip/gzip/' /etc/nginx/nginx.conf && \
     sed -i "/http_x_forwarded_for\"';/s/';/ '/" /etc/nginx/nginx.conf && \
-    sed -i "/http_x_forwarded_for/a \\\
+    sed -i "/http_x_forwarded_for/a \\ \
                       '\$request_time \$upstream_response_time';" \
                 /etc/nginx/nginx.conf && \
     echo -e "\n\nstream {\n    include /etc/nginx/conf.d/*.stream;\n}" \

--- a/nginx.sh
+++ b/nginx.sh
@@ -100,7 +100,7 @@ proxy_request_buffering() { local value="$1" \
 #   org) company
 # Return: self-signed certs will be generated
 gencert() { local domain="${1:-*}" country="${2:-NO}" state="${3:-Rogaland}" \
-            locality="${4:-Sola}" org="{5:-None}" dir=/etc/nginx/ssl
+            locality="${4:-Sola}" org="${5:-None}" dir=/etc/nginx/ssl
     local cert="$dir/fullchain.pem" key="$dir/privkey.pem"
     [[ -e $cert ]] && return
     [[ -d $dir ]] || mkdir -p $dir


### PR DESCRIPTION
The organization name is not set properly in the creation of the SSL certificate. This was due to a typo (forgot one '$' sign). This should fix it.
Note: I'm not sure of the change in the Dockerfile. I needed to change what I did to be able to create the docker image.