### PR TITLE
Add X-Forwarded-Host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN version=$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release) && \
     apk add --no-cache --no-progress nginx && \
     sed -i 's/#gzip/gzip/' /etc/nginx/nginx.conf && \
     sed -i "/http_x_forwarded_for\"';/s/';/ '/" /etc/nginx/nginx.conf && \
-    sed -i "/http_x_forwarded_for/a \\\
-                      '\$request_time \$upstream_response_time';" \
+    sed -i "/http_x_forwarded_for/a \\ \
+                       '\$request_time \$upstream_response_time';" \
                 /etc/nginx/nginx.conf && \
     echo -e "\n\nstream {\n    include /etc/nginx/conf.d/*.stream;\n}" \
                 >>/etc/nginx/nginx.conf && \

--- a/nginx.sh
+++ b/nginx.sh
@@ -457,6 +457,7 @@ proxy() { local service="$1" location="$2" header="${3:-""}" \
         proxy_set_header Host $http_host;\
         proxy_set_header Range $http_range;\
         proxy_set_header If-Range $http_if_range;\
+        proxy_set_header X-Forwarded-Host $host;\
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\
         proxy_set_header X-Forwarded-Proto $scheme;\
         proxy_set_header X-Real-IP $remote_addr;\
@@ -513,6 +514,7 @@ proxy_host() { local service="$1" hosts="$2" header="${3:-""}" \
         proxy_set_header Host $http_host;\
         proxy_set_header Range $http_range;\
         proxy_set_header If-Range $http_if_range;\
+        proxy_set_header X-Forwarded-Host $host;\
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\
         proxy_set_header X-Forwarded-Proto $scheme;\
         proxy_set_header X-Real-IP $remote_addr;\


### PR DESCRIPTION
Some applications like `Odoo` require the `X-Forwarded-Host` header.